### PR TITLE
feat: assign project by item

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ things.create(project)
 
 # create a todo inside project
 todo = TodoItem("Try out Things Cloud")
-todo.project = project.uuid
+todo.project = project
 things.create(todo)
 
 # schedule for today

--- a/main.py
+++ b/main.py
@@ -23,7 +23,7 @@ def main():
     sleep(10)
     # create a todo inside project
     todo = TodoItem("Try out Things Cloud")
-    todo.project = project.uuid
+    todo.project = project
     things.create(todo)
 
     sleep(10)

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -118,7 +118,7 @@ def test_as_project():
     }
 
 
-def test_assign_project():
+def test_assign_project_uuid():
     todo = TodoItem("test task")
     todo.project = "test-project"
     assert todo._projects == ["test-project"]
@@ -133,7 +133,51 @@ def test_assign_project():
     }
 
 
-def test_assign_area():
+def test_assign_project_item():
+    project = TodoItem("test project").as_project()
+    todo = TodoItem("test task")
+    todo.project = project
+    assert todo._projects == [project.uuid]
+    assert todo.project == project.uuid
+    assert isinstance(todo.project, str)
+    assert todo._areas == []
+    assert todo.area is None
+    assert todo.destination == Destination.ANYTIME
+    assert todo.changes == {
+        "_destination",
+        "_projects",
+        "_modification_date",
+    }
+
+
+def test_assign_project_invalid():
+    not_project = TodoItem("not project")
+    todo = TodoItem("test task")
+    with pytest.raises(ValueError):
+        todo.project = not_project
+    assert not todo.project
+    assert not todo.area
+    assert not todo.destination
+    assert not todo.changes
+
+
+def test_clear_project():
+    todo = TodoItem("test task")
+    todo._projects = ["test-project"]
+    assert not todo.changes
+
+    # clear project
+    todo.project = None
+    assert not todo.project
+    assert not todo.area
+    assert not todo.destination
+    assert todo.changes == {
+        "_projects",
+        "_modification_date",
+    }
+
+
+def test_assign_area_uuid():
     todo = TodoItem("test task")
     todo.area = "test-area"
     assert todo._areas == ["test-area"]

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -192,6 +192,22 @@ def test_assign_area_uuid():
     }
 
 
+def test_clear_area():
+    todo = TodoItem("test task")
+    todo._areas = ["test-area"]
+    assert not todo.changes
+
+    # clear area
+    todo.area = None
+    assert not todo.area
+    assert not todo.project
+    assert not todo.destination
+    assert todo.changes == {
+        "_areas",
+        "_modification_date",
+    }
+
+
 def test_deserialize():
     api_object = {
         "ix": 1234,

--- a/things_cloud/models/todo.py
+++ b/things_cloud/models/todo.py
@@ -122,15 +122,24 @@ class TodoItem:
         return self._projects[0] if self._projects else None
 
     @project.setter
-    def project(self, project: str | None) -> None:
+    def project(self, project: TodoItem | str | None) -> None:
+        if isinstance(project, TodoItem):
+            if not project._is_project:
+                raise ValueError("argument must be a project")
+            self._projects = [project.uuid]
+        elif project:
+            self._projects = [project]
         self.modify()
         self._changes.append("_projects")
+
         if not project:
             self._projects.clear()
             return
-        self._projects = [project]
+
+        # clear area
         if self.area:
             self.area = None
+        # move out of inbox
         if self.destination == Destination.INBOX:
             self.destination = Destination.ANYTIME
 

--- a/things_cloud/models/todo.py
+++ b/things_cloud/models/todo.py
@@ -155,8 +155,11 @@ class TodoItem:
             self._areas.clear()
             return
         self._areas = [area]
+
+        # clear project
         if self.project:
             self.project = None
+        # move out of inbox
         if self.destination == Destination.INBOX:
             self.destination = Destination.ANYTIME
 


### PR DESCRIPTION
allows passing `TodoItem` which is marked as project, in addition to the existing option to assign a project uuid directly
